### PR TITLE
Bump versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apk add --no-cache \
 COPY xvfb-run /usr/bin/xvfb-run
 
 ENV PHANTOMJS_VERSION 2.1.1
-ENV CASPERJS_VERSION 1.1.3
-ENV SLIMERJS_VERSION 0.10.1
+ENV CASPERJS_VERSION 1.1.4
+ENV SLIMERJS_VERSION 0.10.3
 
 # Installing dependencies from archives - not only this allows us to control versions, 
 # but the resulting image size is 130MB+ less (!) compared to an npm install (440MB vs 575MB).
@@ -35,8 +35,8 @@ RUN \
 
 RUN \
 	# CasperJS
-	echo "Downloading CaperJS v${CASPERJS_VERSION}..." && \
-	curl -sL "https://github.com/casperjs/casperjs/archive/1.1.3.tar.gz" | tar zx && \
+	echo "Downloading CasperJS v${CASPERJS_VERSION}..." && \
+	curl -sL "https://github.com/casperjs/casperjs/archive/${CASPERJS_VERSION}.tar.gz" | tar zx && \
 	mv casperjs-$CASPERJS_VERSION /opt/casperjs && \
 	ln -s /opt/casperjs/bin/casperjs /usr/bin/casperjs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY xvfb-run /usr/bin/xvfb-run
 ENV PHANTOMJS_VERSION 2.1.1
 ENV CASPERJS_VERSION 1.1.4
 ENV SLIMERJS_VERSION 0.10.3
+ENV BACKSTOPJS_VERSION 2.6.9
 
 # Installing dependencies from archives - not only this allows us to control versions, 
 # but the resulting image size is 130MB+ less (!) compared to an npm install (440MB vs 575MB).
@@ -27,25 +28,25 @@ RUN \
 	mkdir -p /opt && \
 	# PhantomJS
 	echo "Downloading PhantomJS v${PHANTOMJS_VERSION}..." && \
-	curl -sL "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2" | tar jx && \
-	mv phantomjs-$PHANTOMJS_VERSION-linux-x86_64 /opt/phantomjs && \
+	curl -sL "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2" | tar jx && \
+	mv phantomjs-${PHANTOMJS_VERSION}-linux-x86_64 /opt/phantomjs && \
 	ln -s /opt/phantomjs/bin/phantomjs /usr/bin/phantomjs && \
 	echo "Fixing PhantomJS on Alpine" && \
-	curl -sL "https://github.com/dustinblackman/phantomized/releases/download/$PHANTOMJS_VERSION/dockerized-phantomjs.tar.gz" | tar zx -C /
+	curl -sL "https://github.com/dustinblackman/phantomized/releases/download/${PHANTOMJS_VERSION}/dockerized-phantomjs.tar.gz" | tar zx -C /
 
 RUN \
 	# CasperJS
 	echo "Downloading CasperJS v${CASPERJS_VERSION}..." && \
 	curl -sL "https://github.com/casperjs/casperjs/archive/${CASPERJS_VERSION}.tar.gz" | tar zx && \
-	mv casperjs-$CASPERJS_VERSION /opt/casperjs && \
+	mv casperjs-${CASPERJS_VERSION} /opt/casperjs && \
 	ln -s /opt/casperjs/bin/casperjs /usr/bin/casperjs
 
 RUN \
 	# SlimerJS
 	echo "Downloading SlimerJS v${SLIMERJS_VERSION}..." && \
-	curl -sL -O "http://download.slimerjs.org/releases/$SLIMERJS_VERSION/slimerjs-$SLIMERJS_VERSION.zip" && \
-	unzip -q slimerjs-$SLIMERJS_VERSION.zip && rm -f slimerjs-$SLIMERJS_VERSION.zip && \
-	mv slimerjs-$SLIMERJS_VERSION /opt/slimerjs && \
+	curl -sL -O "http://download.slimerjs.org/releases/${SLIMERJS_VERSION}/slimerjs-${SLIMERJS_VERSION}.zip" && \
+	unzip -q slimerjs-${SLIMERJS_VERSION}.zip && rm -f slimerjs-${SLIMERJS_VERSION}.zip && \
+	mv slimerjs-${SLIMERJS_VERSION} /opt/slimerjs && \
 	# Run slimer with xvfb
 	echo '#!/usr/bin/env bash\nxvfb-run /opt/slimerjs/slimerjs "$@"' > /opt/slimerjs/slimerjs.sh && \
 	chmod +x /opt/slimerjs/slimerjs.sh && \
@@ -53,8 +54,8 @@ RUN \
 
 RUN \
 	# BackstopJS
-	echo "Installing BackstopJS..." && \
-	npm install -g garris/backstopjs
+	echo "Installing BackstopJS v${BACKSTOPJS_VERSION}..." && \
+	npm install -g backstopjs@${BACKSTOPJS_VERSION}
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM mhart/alpine-node:4.5
-
-MAINTAINER Leonid Makarov <leonid.makarov@ffwagency.com>
+FROM mhart/alpine-node:6.10.0
 
 RUN apk add --no-cache \
 	bash \


### PR DESCRIPTION
Hey!
I was having some trouble with permissions on the reports that are written, and was trying to add a '--user' flag to run the container as a given uid.  This doesn't seem to work the way things are now, and I get:

```
BackstopJS CWD:  /src
BackstopJS loading config:  /src/backstop.js 

COMMAND | Executing core for `test`
COMMAND | Command `test` ended with an error
COMMAND | Error: EACCES: permission denied, open '/usr/lib/node_modules/backstopjs/capture/config.json'
              at Error (native)
```

Which makes sense, right?  The weird thing is I tried updating the dependencies (bumping the Slimer and Casper versions), and it fixes the issue.  Not really sure why, but here's a PR to bump those versions.  If you want to check this out without building it, I created an image off of my fork here: https://hub.docker.com/r/docksal/backstopjs/